### PR TITLE
Extending package to work with aov objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: contrast
-Version: 0.21
-Date: 2016-09-22
+Version: 0.21-1
+Date: 2017-02-22
 Title: A Collection of Contrast Methods
 Author: Max Kuhn, contributions from Steve Weston, Jed Wing, 
   James Forester and Thorn Thaler 

--- a/R/print.contrast.R
+++ b/R/print.contrast.R
@@ -2,10 +2,12 @@
 # It was copied from the rms package, written by Frank Harrell.
 print.contrast <- function(x, X=FALSE, fun=function(u) u, ...)
 {
-   testLabels <- switch(
-      x$model,
-      lm =, glm =, lme =, gls = c("t", "Pr(>|t|)"),
-      geese = c("Z", "Pr(>|Z|)"))
+  if (inherits(x$model, "geese"))
+    testLabels <- c("Z", "Pr(>|Z|)")
+  else if (inherits(x$model, "gls") || inherits(x$model, "lme") || inherits(x$model, "lm"))
+    testLabels <- c("t", "Pr(>|t|)")
+  else
+    testLabels <- NA
       
    w <- x[c("Contrast", "SE", "Lower", "Upper", "testStat", "df", "Pvalue")]
    w$testStat <- round(w$testStat, 2)

--- a/R/testStatistic.R
+++ b/R/testStatistic.R
@@ -1,42 +1,71 @@
 ## this is a utility function that is called from contrast.lm
-testStatistic <- function(fit, 
-                          designMatrix, 
-                          params=getCoefficients(fit), 
-                          covMatrix=vcov(fit), 
+testStatistic <- function(fit,
+                          designMatrix,
+                          params = getCoefficients(fit),
+                          covMatrix = vcov(fit),
                           conf.int = 0.95)
 {
   est <- drop(designMatrix %*% params)
   v <- drop((designMatrix %*% covMatrix) %*% t(designMatrix))
-  ndf <- if (is.matrix(v)) nrow(v) else 1
-  se <- if (ndf == 1) sqrt(v) else sqrt(diag(v))
+  ndf <- if (is.matrix(v))
+    nrow(v)
+  else
+    1
+  se <- if (ndf == 1)
+    sqrt(v)
+  else
+    sqrt(diag(v))
   testStat <- est / se
   
-  if(class(fit)[1] == "lme" && class(fit$apVar)[1] == "character") stop(fit$apVar)
+  if (class(fit)[1] == "lme" &&
+      class(fit$apVar)[1] == "character")
+    stop(fit$apVar)
   
   ## this is inconsistent theoretically, but consistent with each R model
-  dfdm <- switch(class(fit)[1],
-                 lm =, glm = fit$df.residual,
-                 gls = fit$dims$N -  fit$dims$p,
-                 lme = fit$dims$N -  length(params) - length(coef(fit$modelStruct)) - 1,      
-                 geese = NA)
+  if (inherits(fit, "geese"))
+    dfdm <- NA
+  else if (inherits(fit, "lme"))
+    dfdm <-
+    fit$dims$N -  length(params) -> length(coef(fit$modelStruct)) - 1
+  else if (inherits(fit, "gls"))
+    dfdm <- fit$dims$N -  fit$dims$p
+  else if (inherits(fit, "lm"))
+    dfdm <- fit$df.residual
+  else
+    dfdm <- NA
   
-  critVal <- if (!(class(fit)[1] %in% "geese")) qt((1 + conf.int) / 2, dfdm) else qnorm((1 + conf.int) / 2)
   
-  P <- switch(class(fit)[1],
-              lm =,
-              glm =  if(length(dfdm) > 0 && dfdm[1] > 0) 2 * (1 - pt(abs(testStat), dfdm)) else 2 * (1 - pnorm(abs(testStat), dfdm)),
-              gls = 2 * (1 - pt(abs(testStat), dfdm)),
-              lme = 2 * (1 - pt(abs(testStat), dfdm)),      
-              geese = 2 * (1 - pnorm(abs(testStat))))
+  critVal <-
+    if (!(class(fit)[1] %in% "geese"))
+      qt((1 + conf.int) / 2, dfdm)
+  else
+    qnorm((1 + conf.int) / 2)
   
-  list(Contrast=est,
-       SE=se,
-       Lower=est - critVal * se,
-       Upper=est + critVal * se,
-       testStat=testStat,
-       df = dfdm,
-       Pvalue=P,
-       var=v,
-       X=designMatrix,
-       df.residual = dfdm)
+  if (inherits(fit, "geese"))
+    P <- 2 * (1 - pnorm(abs(testStat)))
+  else if (inherits(fit, "lme"))
+    P <- 2 * (1 - pt(abs(testStat), dfdm))
+  else if (inherits(fit, "gls"))
+    P <- 2 * (1 - pt(abs(testStat), dfdm))
+  else if (inherits(fit, "lm")) {
+    if (length(dfdm) > 0 && dfdm[1] > 0)
+      P <- 2 * (1 - pt(abs(testStat), dfdm))
+    else
+      P <- 2 * (1 - pnorm(abs(testStat), dfdm))
+  }
+  else
+    P <- NA
+  
+  list(
+    Contrast = est,
+    SE = se,
+    Lower = est - critVal * se,
+    Upper = est + critVal * se,
+    testStat = testStat,
+    df = dfdm,
+    Pvalue = P,
+    var = v,
+    X = designMatrix,
+    df.residual = dfdm
+  )
 }


### PR DESCRIPTION
Replaced switch statements with if else statements based on inherits() to identify class. This allows the package to work with aov objects (and any other object inheriting from lm).